### PR TITLE
perf: Comment 관련 페이지에 날씨 아이콘 추가, plan 페이지와 comment 페이지 연결

### DIFF
--- a/src/app/plan/components/CommentsLink.tsx
+++ b/src/app/plan/components/CommentsLink.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { WeatherApiResponse } from '@/app/plan/types';
+import Link from 'next/link';
+
+interface CommentsLinkProps {
+  weatherData: WeatherApiResponse | null;
+  locationName: string;
+}
+
+const CommentsLink: React.FC<CommentsLinkProps> = ({ weatherData, locationName }) => {  
+  const travelDate = (weatherData && weatherData.length > 0 && weatherData[0].date)
+  ? weatherData[0].date
+  : ''; // 날짜가 없을 경우 빈 문자열로 설정 (null 대신)
+
+  if(weatherData === null) return;
+
+  return (
+    <div className="mt-6 pb-4">
+      <div className="border-t border-gray-200 pt-4">
+        <Link
+          href={{
+            pathname: "/comments",
+            query: {
+                location: locationName,
+                ...(travelDate ? { date: travelDate } : {}),
+            },
+          }}
+            className="w-full flex items-center justify-center space-x-2 text-blue-600 active:text-blue-800 font-medium py-3 rounded-lg active:bg-blue-50 transition-colors duration-200"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+          </svg>
+          <span>관련 Log 보러가기</span>
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default CommentsLink;

--- a/src/app/plan/components/ResultsDisplay.tsx
+++ b/src/app/plan/components/ResultsDisplay.tsx
@@ -4,8 +4,8 @@
 import React from 'react';
 import WeatherResults from './WeatherResults';
 import ClothResults from './ClothResults';
+import CommentsLink from './CommentsLink';
 import { ClothApiResponse, WeatherApiResponse } from '@/app/plan/types';
-import Link from 'next/link';
 
 interface ResultsDisplayProps {
   isLoading: boolean;
@@ -42,91 +42,11 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
     );
   }
 
-  const travelDate = (weatherData && weatherData.length > 0 && weatherData[0].date)
-    ? weatherData[0].date
-    : ''; // 날짜가 없을 경우 빈 문자열로 설정 (null 대신)
-
   return (
     <div className="w-full h-full overflow-y-auto">
       <WeatherResults weatherData={weatherData} locationName={locationName} />
       <ClothResults clothData={clothData} />
-      {(clothData || weatherData) && (
-        <div className="mt-6 pb-4">
-        {/* 옵션 1: 모바일 최적화 카드 */}
-        <div className="bg-gradient-to-r from-blue-50 to-indigo-100 rounded-2xl p-4 border border-blue-200 shadow-sm">
-          <div className="flex items-center space-x-3 mb-3">
-            <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center flex-shrink-0">
-              <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-              </svg>
-            </div>
-            <div className="flex-1">
-              <h3 className="text-base font-semibold text-gray-800">다른 여행자들의 후기</h3>
-              <p className="text-xs text-gray-600 mt-1">생생한 여행 경험을 확인해보세요</p>
-            </div>
-          </div>
-          <Link
-            href={{
-              pathname: "/comments",
-              query: {
-                location: locationName,
-                ...(travelDate ? { date: travelDate } : {}),
-              },
-            }}
-            className="w-full bg-blue-600 active:bg-blue-700 text-white py-3 px-4 rounded-xl font-medium transition-colors duration-200 flex items-center justify-center space-x-2 shadow-md active:shadow-lg"
-          >
-            <span>관련 Log 보러가기</span>
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
-        </div>
-
-        {/* 옵션 2: 모바일 플로팅 버튼 스타일 */}
-        {/* <div className="text-center">
-          <Link
-            href={{
-              pathname: "/comments",
-              query: {
-                location: locationName,
-                ...(travelDate ? { date: travelDate } : {}),
-              },
-            }}
-            className="inline-flex items-center space-x-3 bg-white border-2 border-blue-300 text-blue-700 px-6 py-4 rounded-full font-medium active:bg-blue-50 active:border-blue-400 transition-all duration-200 shadow-lg active:shadow-xl"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
-            <span>여행 Log 구경하기</span>
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
-            </svg>
-          </Link>
-        </div> */}
-
-        {/* 옵션 3: 모바일 미니멀 스타일 */}
-        {/* <div className="border-t border-gray-200 pt-4">
-          <Link
-            href={{
-              pathname: "/comments",
-              query: {
-                location: locationName,
-                ...(travelDate ? { date: travelDate } : {}),
-              },
-            }}
-            className="w-full flex items-center justify-center space-x-2 text-blue-600 active:text-blue-800 font-medium py-3 rounded-lg active:bg-blue-50 transition-colors duration-200"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
-            <span>관련 Log 보러가기</span>
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
-        </div> */}
-      </div>
-      )}
+      <CommentsLink weatherData={weatherData} locationName={locationName} />
     </div>
   );
 };

--- a/src/app/plan/components/ResultsDisplay.tsx
+++ b/src/app/plan/components/ResultsDisplay.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import WeatherResults from './WeatherResults';
 import ClothResults from './ClothResults';
 import { ClothApiResponse, WeatherApiResponse } from '@/app/plan/types';
+import Link from 'next/link';
 
 interface ResultsDisplayProps {
   isLoading: boolean;
@@ -41,10 +42,91 @@ const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
     );
   }
 
+  const travelDate = (weatherData && weatherData.length > 0 && weatherData[0].date)
+    ? weatherData[0].date
+    : ''; // 날짜가 없을 경우 빈 문자열로 설정 (null 대신)
+
   return (
     <div className="w-full h-full overflow-y-auto">
       <WeatherResults weatherData={weatherData} locationName={locationName} />
       <ClothResults clothData={clothData} />
+      {(clothData || weatherData) && (
+        <div className="mt-6 pb-4">
+        {/* 옵션 1: 모바일 최적화 카드 */}
+        <div className="bg-gradient-to-r from-blue-50 to-indigo-100 rounded-2xl p-4 border border-blue-200 shadow-sm">
+          <div className="flex items-center space-x-3 mb-3">
+            <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center flex-shrink-0">
+              <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+              </svg>
+            </div>
+            <div className="flex-1">
+              <h3 className="text-base font-semibold text-gray-800">다른 여행자들의 후기</h3>
+              <p className="text-xs text-gray-600 mt-1">생생한 여행 경험을 확인해보세요</p>
+            </div>
+          </div>
+          <Link
+            href={{
+              pathname: "/comments",
+              query: {
+                location: locationName,
+                ...(travelDate ? { date: travelDate } : {}),
+              },
+            }}
+            className="w-full bg-blue-600 active:bg-blue-700 text-white py-3 px-4 rounded-xl font-medium transition-colors duration-200 flex items-center justify-center space-x-2 shadow-md active:shadow-lg"
+          >
+            <span>관련 Log 보러가기</span>
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </Link>
+        </div>
+
+        {/* 옵션 2: 모바일 플로팅 버튼 스타일 */}
+        {/* <div className="text-center">
+          <Link
+            href={{
+              pathname: "/comments",
+              query: {
+                location: locationName,
+                ...(travelDate ? { date: travelDate } : {}),
+              },
+            }}
+            className="inline-flex items-center space-x-3 bg-white border-2 border-blue-300 text-blue-700 px-6 py-4 rounded-full font-medium active:bg-blue-50 active:border-blue-400 transition-all duration-200 shadow-lg active:shadow-xl"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+            </svg>
+            <span>여행 Log 구경하기</span>
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+            </svg>
+          </Link>
+        </div> */}
+
+        {/* 옵션 3: 모바일 미니멀 스타일 */}
+        {/* <div className="border-t border-gray-200 pt-4">
+          <Link
+            href={{
+              pathname: "/comments",
+              query: {
+                location: locationName,
+                ...(travelDate ? { date: travelDate } : {}),
+              },
+            }}
+            className="w-full flex items-center justify-center space-x-2 text-blue-600 active:text-blue-800 font-medium py-3 rounded-lg active:bg-blue-50 transition-colors duration-200"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+            </svg>
+            <span>관련 Log 보러가기</span>
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </Link>
+        </div> */}
+      </div>
+      )}
     </div>
   );
 };

--- a/src/features/comment/components/CommentCard.tsx
+++ b/src/features/comment/components/CommentCard.tsx
@@ -19,7 +19,7 @@ export function CommentCard({ comment }: CommentCardProps) {
         </h1>
             
         {/* Meta Info */}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mt-4">
+        <div className="flex flex-row items-center justify-between gap-2 mt-4">
           <div className="flex items-center gap-2 text-sm text-gray-600">
             <span className="truncate">{comment.email}</span>
           </div>

--- a/src/features/comment/components/CommentItem.tsx
+++ b/src/features/comment/components/CommentItem.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
-import { MapPin, Thermometer } from "lucide-react";
+import { MapPin, Thermometer, CloudLightning, CloudDrizzle, CloudRain, CloudSnow, CloudFog, Sun, Cloud, ThermometerSun } from "lucide-react";
 import type { components } from "@/lib/backend/apiV1/schema";
 
 type CommentDto = components["schemas"]["CommentDto"];
@@ -12,6 +12,20 @@ interface CommentItemProps {
   index: number;
   totalElements: number;
   page: number;
+}
+
+function getWeatherIconByCode(code: number) {
+  if (code >= 200 && code < 300) return <CloudLightning className="text-yellow-300 w-5 h-5" />;
+  if (code >= 300 && code < 400) return <CloudDrizzle className="text-blue-300 w-5 h-5" />;
+  if (code >= 500 && code < 600) return <CloudRain className="text-blue-500 w-5 h-5" />;
+  if (code >= 600 && code < 700) return <CloudSnow className="text-gray-300 w-5 h-5" />;
+  if (code >= 700 && code < 800) return <CloudFog className="text-gray-400 w-5 h-5" />;
+  if (code === 800) return <Sun className="text-yellow-400 w-5 h-5" />;
+  if (code > 800 && code < 900) return <Cloud className="text-gray-300 w-5 h-5" />;
+  if (code === 900) return <ThermometerSun className="text-red-500 w-5 h-5" />;
+
+  console.warn(`Unknown weather code: ${code}`);
+  return <Sun className="text-yellow-300 w-5 h-5" />;
 }
 
 export function CommentItem({ comment, index, totalElements, page }: CommentItemProps) {
@@ -51,6 +65,7 @@ export function CommentItem({ comment, index, totalElements, page }: CommentItem
                   <span>{comment.weatherInfoDto.feelsLikeTemperature}°C</span>
                 </div>
               )}
+              {comment.weatherInfoDto.weatherCode && getWeatherIconByCode(comment.weatherInfoDto.weatherCode)}
             </div>
           </div>
 

--- a/src/features/comment/components/CommentsMain.tsx
+++ b/src/features/comment/components/CommentsMain.tsx
@@ -12,17 +12,37 @@ import { LoadingSpinner } from "./LoadingSpinner";
 import type { components } from "@/lib/backend/apiV1/schema";
 import { apiFetch } from "@/lib/backend/client";
 import { SearchFiltersType } from "../types";
+import { useSearchParams } from "next/navigation";
 
 type CommentDto = components["schemas"]["CommentDto"];
 
 export default function CommentsMain() {
+  const searchParams = useSearchParams();
+
   const [comments, setComments] = useState<CommentDto[] | null>(null);
   const [showModal, setShowModal] = useState(false);
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [totalElements, setTotalElements] = useState(0);
 
-  const [filters, setFilters] = useState<SearchFiltersType>({});
+  const [filters, setFilters] = useState<SearchFiltersType>(() => {
+    const initialLocation = searchParams.get('location');
+    const initialDate = searchParams.get('date'); // 'date' 파라미터도 있다면
+    const initialMonth = initialDate ? new Date(initialDate).getMonth() + 1 : undefined; // 날짜에서 월 추출
+    // const initialFeelsLikeTemperature = searchParams.get('feelsLikeTemperature');
+
+    const initialFilters: SearchFiltersType = {};
+    if (initialLocation) {
+      initialFilters.location = initialLocation;
+    }
+    if (initialMonth !== undefined) {
+      initialFilters.month = initialMonth;
+    }
+    // if (initialFeelsLikeTemperature) {
+    //   initialFilters.feelsLikeTemperature = parseFloat(initialFeelsLikeTemperature);
+    // }
+    return initialFilters;
+  });
 
   const fetchComments = async (currentPage: number, searchFilters: SearchFiltersType) => {
     const params = new URLSearchParams({
@@ -70,7 +90,7 @@ export default function CommentsMain() {
 
       <div className="px-4 py-6 max-w-4xl mx-auto">
         <div className="bg-white rounded-2xl shadow-sm border border-gray-100 mb-6 overflow-hidden">
-          <SearchFilters onFiltersChange={handleFiltersChange} />
+          <SearchFilters onFiltersChange={handleFiltersChange} initialFilters={filters} />
           <ActiveFilters filters={filters} onFiltersChange={handleFiltersChange} />
         </div>
 

--- a/src/features/comment/components/SearchFilters.tsx
+++ b/src/features/comment/components/SearchFilters.tsx
@@ -5,15 +5,16 @@ import { Search, ChevronRight, MapPin, Thermometer, Calendar, Mail } from "lucid
 import { SearchFiltersType } from "../types";
 
 interface SearchFiltersProps {
-  onFiltersChange: (filters: SearchFiltersType) => void;
+  onFiltersChange: (filters: SearchFiltersType) => void,
+  initialFilters?: SearchFiltersType;
 }
 
-export function SearchFilters({ onFiltersChange }: SearchFiltersProps) {
+export function SearchFilters({ onFiltersChange, initialFilters }: SearchFiltersProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [tempInputs, setTempInputs] = useState({
-    location: "",
+    location: initialFilters?.location || "",
     feelsLikeTemperature: "",
-    month: "",
+    month: initialFilters?.month || "",
     email: ""
   });
 

--- a/src/features/comment/components/WeatherInfo.tsx
+++ b/src/features/comment/components/WeatherInfo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MapPin, Thermometer, Calendar } from "lucide-react";
+import { MapPin, Thermometer, Calendar, CloudLightning, CloudDrizzle, CloudRain, CloudSnow, CloudFog, Sun, Cloud, ThermometerSun } from "lucide-react";
 import type { components } from "@/lib/backend/apiV1/schema";
 
 type WeatherInfoDto = components["schemas"]["CommentDto"]["weatherInfoDto"];
@@ -8,11 +8,25 @@ interface WeatherInfoProps {
   weatherInfo: WeatherInfoDto;
 }
 
+function getWeatherIconByCode(code: number) {
+  if (code >= 200 && code < 300) return <CloudLightning className="text-yellow-300 w-5 h-5" />;
+  if (code >= 300 && code < 400) return <CloudDrizzle className="text-blue-300 w-5 h-5" />;
+  if (code >= 500 && code < 600) return <CloudRain className="text-blue-500 w-5 h-5" />;
+  if (code >= 600 && code < 700) return <CloudSnow className="text-gray-300 w-5 h-5" />;
+  if (code >= 700 && code < 800) return <CloudFog className="text-gray-400 w-5 h-5" />;
+  if (code === 800) return <Sun className="text-yellow-400 w-5 h-5" />;
+  if (code > 800 && code < 900) return <Cloud className="text-gray-300 w-5 h-5" />;
+  if (code === 900) return <ThermometerSun className="text-red-500 w-5 h-5" />;
+
+  console.warn(`Unknown weather code: ${code}`);
+  return <Sun className="text-yellow-300 w-5 h-5" />;
+}
+
 export function WeatherInfo({ weatherInfo }: WeatherInfoProps) {
   return (
     <div className="p-4 sm:p-6 bg-gray-50 border-b border-gray-100">
       <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
-        <Thermometer size={16} />
+        {weatherInfo.weatherCode && getWeatherIconByCode(weatherInfo.weatherCode)}
         날씨 정보
       </h3>
       <div className="grid grid-cols-3 gap-3">


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

-

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

- Comment 목록 및 상세 페이지에 날씨 아이콘 추가
- plan 페이지에서 관련 comment 목록 볼 수 있도록 링크 추가
  - CommentsLink 컴포넌트 추가

<img width="388" height="843" alt="image" src="https://github.com/user-attachments/assets/2ea29e80-ea07-4677-8db1-a604c6b4693c" />
<img width="390" height="842" alt="image" src="https://github.com/user-attachments/assets/2535e4b4-8485-43c5-93e8-f1b08aec0e67" />


## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #51

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 댓글 페이지로 이동하는 링크 컴포넌트가 추가되어, 여행지와 날짜 정보를 기반으로 쉽게 이동할 수 있습니다.
  * 댓글 내 날씨 정보에 실제 날씨 상태에 맞는 아이콘이 표시됩니다.

* **개선 사항**
  * 댓글 목록 필터가 URL의 위치 및 날짜 쿼리 파라미터를 자동 반영하여 초기화됩니다.
  * 댓글 필터 UI가 초기값을 받을 수 있도록 개선되었습니다.

* **스타일**
  * 댓글 카드의 레이아웃이 반응형에서 고정 가로 정렬로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->