### PR TITLE
fix: plan 페이지 이미지 로드 오류 해결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,8 +4,8 @@ const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
       {
-        protocol: 'http',
-        hostname: 'example.com',
+        protocol: 'https',
+        hostname: 'i.postimg.cc',
         port: '',
         pathname: '/**',
       },


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

-

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

- next.js.ts에서 외부 이미지 호스트 i.post.cc 허용

<img width="388" height="844" alt="image" src="https://github.com/user-attachments/assets/b5b647f8-eeb8-4ce9-8a1d-a3501da37e5f" />

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #55

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 원격 이미지 로딩 시 허용된 이미지 소스가 변경되어, 이제 'i.postimg.cc'의 'https' 이미지만 정상적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->